### PR TITLE
Fix "error: unary negation of unsigned integers may be removed in the future"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@ impl DrawState {
         let side = state::StencilSide {
             fun: fun,
             value: value,
-            mask_read: -1,
-            mask_write: -1,
+            mask_read: Stencil::max_value(),
+            mask_write: Stencil::max_value(),
             op_fail: StencilOp::Keep,
             op_depth_fail: StencilOp::Keep,
             op_pass: StencilOp::Keep,

--- a/src/state.rs
+++ b/src/state.rs
@@ -167,8 +167,8 @@ impl Default for StencilSide {
         StencilSide {
             fun: Comparison::Always,
             value: 0,
-            mask_read: -1,
-            mask_write: -1,
+            mask_read: target::Stencil::max_value(),
+            mask_write: target::Stencil::max_value(),
             op_fail: StencilOp::Keep,
             op_depth_fail: StencilOp::Keep,
             op_pass: StencilOp::Keep,


### PR DESCRIPTION
Instead of using integer underflow to get maximum value for current type, use builtin integer method.

Otherwise code fails to compile with rustc 1.0.0-nightly (d17d6e7f1 2015-04-02) (built 2015-04-03).
