### PR TITLE
Update bitflags to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "draw_state"
-version = "0.3.0"
+version = "0.3.1"
 description = "Graphics state blocks for gfx-rs"
 homepage = "https://github.com/gfx-rs/draw_state"
 repository = "https://github.com/gfx-rs/draw_state"
@@ -27,4 +27,4 @@ name = "draw_state"
 path = "src/lib.rs"
 
 [dependencies]
-bitflags = "0.3.2"
+bitflags = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "draw_state"
-version = "0.3.1"
+version = "0.4.0"
 description = "Graphics state blocks for gfx-rs"
 homepage = "https://github.com/gfx-rs/draw_state"
 repository = "https://github.com/gfx-rs/draw_state"


### PR DESCRIPTION
The bitflags version update is self explanatory; the new version 0.4.0 exists.

The gfx crate depends on draw_state so to test these changes the following actions were performed on gfx:
cargo build
cargo run --example triangle
cargo run --example cube
cargo run --example deferred
All of the above built successfully and the examples ran successfully.
